### PR TITLE
Ensure OpenRouter API base is configured correctly

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,11 +21,11 @@ if not TWILIO_AUTH_TOKEN:
 
 # OpenRouter API Key
 OPENROUTER_API_KEY = os.environ.get("OPENROUTER_API_KEY")
-if OPENROUTER_API_KEY:
-    openai.api_key = OPENROUTER_API_KEY
-    openai.base_url = "https://openrouter.ai/api/v1"
-else:
-    app.logger.warning("OPENROUTER_API_KEY is not set")
+if not OPENROUTER_API_KEY:
+    raise RuntimeError("OPENROUTER_API_KEY is not set")
+
+openai.api_key = OPENROUTER_API_KEY
+openai.api_base = "https://openrouter.ai/api/v1"
 
 def check_auth(username, password):
     return username == WEBHOOK_USER and password == WEBHOOK_PASS


### PR DESCRIPTION
## Summary
- Switch from `openai.base_url` to `openai.api_base` pointing to `https://openrouter.ai/api/v1`
- Halt startup if `OPENROUTER_API_KEY` is missing to avoid misconfigured deployments

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`
- `python app.py` (received 401 response from index)


------
https://chatgpt.com/codex/tasks/task_e_68bd7a5f08d48325ad89609e539d2286