### PR TITLE
Limit LLM response size

### DIFF
--- a/app.py
+++ b/app.py
@@ -142,7 +142,14 @@ def webhook():
     def generate_reply(prompt: str) -> str:
         response = openai.ChatCompletion.create(
             model=OPENROUTER_MODEL,
-            messages=[{"role": "user", "content": prompt}]
+            # Twilio imposes a 1600-character limit per message. Capping tokens
+            # helps keep typical responses safely below this ceiling (≈4 chars
+            # per token gives ~1400 characters at 350 tokens).
+            max_tokens=350,
+            messages=[
+                {"role": "system", "content": "Keep responses concise."},
+                {"role": "user", "content": prompt},
+            ],
         )
         if response.choices:
             return response.choices[0].message["content"].strip()


### PR DESCRIPTION
## Summary
- Cap OpenRouter replies at 350 tokens and request concise answers
- Document Twilio 1600-character constraint

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'
max_tokens = 350
approx_chars = max_tokens * 4
print(f"Approximate characters at {max_tokens} tokens: {approx_chars}")
print('Within Twilio limit?', approx_chars < 1600)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bff8d5026483258c4722feb0452af3